### PR TITLE
New version of snabbdom use ES6 modules so we need to add .default to imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snabbdom-edge",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "The I/O for snabbdom (write HTML on server and read DOM on client).",
   "main": "index.js",
   "scripts": {

--- a/read-dom/index.js
+++ b/read-dom/index.js
@@ -1,4 +1,4 @@
-var VNode = require("snabbdom/vnode");
+var VNode = require("snabbdom/vnode").default;
 var entities = require("html-entities/lib/html5-entities").prototype;
 
 function readNode(hooks, elm) {


### PR DESCRIPTION
I also changed the version number so it indicate that it is not compatible with older versions. Also I have added the package to npm.org and would be happy to add you to that package,